### PR TITLE
New: Add Cardigann v12 allowtvsearchimdb support

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
@@ -250,6 +250,11 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
             capabilities.ParseCardigannSearchModes(definition.Caps.Modes);
             capabilities.SupportsRawSearch = definition.Caps.Allowrawsearch;
 
+            if (definition.Caps.Allowtvsearchimdb && !capabilities.TvSearchParams.Contains(TvSearchParam.ImdbId))
+            {
+                capabilities.TvSearchParams.Add(TvSearchParam.ImdbId);
+            }
+
             if (definition.Caps.Categories != null && definition.Caps.Categories.Any())
             {
                 foreach (var category in definition.Caps.Categories)

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannDefinition.cs
@@ -78,6 +78,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
         public List<CategorymappingBlock> Categorymappings { get; set; }
         public Dictionary<string, List<string>> Modes { get; set; }
         public bool Allowrawsearch { get; set; }
+        public bool Allowtvsearchimdb { get; set; }
     }
 
     public class CaptchaBlock

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -122,6 +122,12 @@ namespace NzbDrone.Core.Indexers
             definition.Capabilities = new IndexerCapabilities();
             definition.Capabilities.ParseCardigannSearchModes(defFile.Caps.Modes);
             definition.Capabilities.SupportsRawSearch = defFile.Caps.Allowrawsearch;
+
+            if (defFile.Caps.Allowtvsearchimdb && !definition.Capabilities.TvSearchParams.Contains(TvSearchParam.ImdbId))
+            {
+                definition.Capabilities.TvSearchParams.Add(TvSearchParam.ImdbId);
+            }
+
             MapCardigannCategories(definition, defFile);
         }
 


### PR DESCRIPTION
Adds support for the allowtvsearchimdb capability flag in Cardigann
definition files, allowing indexers to explicitly enable IMDB search
for TV content.